### PR TITLE
feat: add addtional check in Wordle initialization

### DIFF
--- a/recitation-8/README.md
+++ b/recitation-8/README.md
@@ -4,10 +4,6 @@ __Wode "Nimo" Ni__
 
 _22/03/25_
 
-## Review code
-
-Let's review Nimo's most recent change to the wordle example from recitation 4.
-
 ## Open issues
 
 * In `word.json`, pick your least favorite word, and open an issue to ask for its removal.
@@ -41,3 +37,10 @@ Let's review Nimo's most recent change to the wordle example from recitation 4.
   * Approve the change
 * Close the PR
   * Use the "Squash and Merge" option
+
+## Review code
+
+Let's review Nimo's most recent change to the wordle example.
+
+
+

--- a/recitation-8/wordle.py
+++ b/recitation-8/wordle.py
@@ -34,8 +34,8 @@ class WordleGame:
         Constructs a `WordleGame` object with an optional `answer` word.
         """
         self.words = words
-        # if there's a predefined answer, use it
-        if answer:
+        # if there's a predefined answer and that answer is in the dictionary, use it
+        if answer and answer in words.keys():
             self.answer_word = answer
         # otherwise, generate a new answer word from the dictionary
         else:

--- a/recitation-8/wordle_test.py
+++ b/recitation-8/wordle_test.py
@@ -1,5 +1,5 @@
 from wordle import guess_in_dict, unique, hint_repeated_char, positions, \
-    check_guess, valid_guess_length, pick_word, CORRECT, IN_WORD, INCORRECT
+    check_guess, valid_guess_length, pick_word, CORRECT, IN_WORD, INCORRECT, load_words, WordleGame
 
 
 def test_hint_repeated_char():
@@ -121,4 +121,9 @@ def test_gid_pizza():
 def test_gid_pizz():
     assert not(guess_in_dict('pizz', {'pizza': None}))
 
-# TODO write at least one test for `pick_word`
+
+def test_setup_anwser_animo():
+    dict_path = './words.json'
+    dictionary = load_words(dict_path)
+    wordle = WordleGame(dictionary, answer="animo")
+    assert wordle.answer_word == "animo"


### PR DESCRIPTION
# Description

The original Wordle game allows an `answer` parameter for testing. Instead of allowing arbitrary words as a parameter, I added an additional check to make sure `answer` is actually in the dictionary. 

# Open questions

* My tests are failing, not really sure why tho. Can you help me?